### PR TITLE
Don't pass compiler's optimize flags to ld

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for ExtUtils-HasCompiler
 
 {{$NEXT}}
+          - Don't pass the compiler's optimization flags to the ld command. On
+            systems where these two commands are different (AIX and some
+            version of HPUX among them), the ld command may not accept these
+            optimization flags. (Dave Rolsky, GH #9)
 
 0.016     2016-07-05 10:06:29+02:00 Europe/Amsterdam
           - Stable release without modifications since 0.015

--- a/lib/ExtUtils/HasCompiler.pm
+++ b/lib/ExtUtils/HasCompiler.pm
@@ -124,7 +124,7 @@ sub can_compile_loadable_object {
 			push @extra, qq{"-L$incdir"}, '-lperl', $perllibs;
 		}
 		push @commands, qq{$cc $ccflags $optimize "-I$incdir" $cccdlflags -c $source_name -o $object_file};
-		push @commands, qq{$ld $optimize $object_file -o $loadable_object $lddlflags @extra};
+		push @commands, qq{$ld $object_file -o $loadable_object $lddlflags @extra};
 	}
 
 	for my $command (@commands) {


### PR DESCRIPTION
On systems where the ld command is not the same as the compiler, there's no
reason to assume that these flags are valid for the linker. I encountered this
on AIX and HPUX IA64, but this could apply anywhere, AFAICT.

This supersedes #8.