### PR TITLE
Fixes issue #11. Adds support for MSYS2.

### DIFF
--- a/lib/ExtUtils/HasCompiler.pm
+++ b/lib/ExtUtils/HasCompiler.pm
@@ -104,7 +104,7 @@ sub can_compile_loadable_object {
 			my $lib = '-l' . ($libperl =~ /lib([^.]+)\./)[0];
 			push @extra, "$abs_basename.def", $lib, $perllibs;
 		}
-		elsif ($^O eq 'cygwin') {
+		elsif ($^O =~ /^(cygwin|msys)$/) {
 			push @extra, catfile($incdir, $config->get('useshrplib') ? 'libperl.dll.a' : 'libperl.a');
 		}
 		elsif ($^O eq 'aix') {


### PR DESCRIPTION
Fixes issue #11. As far as I can see, it is enough to do the same thing for `msys2` as with `cygwin`.